### PR TITLE
Guest feature for Actor-core & keyvalue

### DIFF
--- a/rust/actor-core/Cargo.toml
+++ b/rust/actor-core/Cargo.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+guest = ["wapc-guest"]
 
 [dependencies]
-wapc-guest = "0.4.0"
+wapc-guest = { version = "0.4.0", optional = true }
 serde = { version = "1.0.118" , features = ["derive"] }
 serde_json = "1.0.60"
 serde_bytes = "0.11.5"

--- a/rust/actor-core/Cargo.toml
+++ b/rust/actor-core/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0.118" , features = ["derive"] }
 serde_json = "1.0.60"
 serde_bytes = "0.11.5"
 rmp-serde = "0.15.0"
-log = { version="0.4.11", features =["std","serde"]}
+log = { version="0.4.13", features =["std","serde"]}
 lazy_static = "1.4.0"

--- a/rust/actor-core/src/generated.rs
+++ b/rust/actor-core/src/generated.rs
@@ -4,16 +4,22 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
 extern crate log;
+
+#[cfg(feature = "guest")]
 extern crate wapc_guest as guest;
+#[cfg(feature = "guest")]
 use guest::prelude::*;
 
+#[cfg(feature = "guest")]
 use lazy_static::lazy_static;
+#[cfg(feature = "guest")]
 use std::sync::RwLock;
 
 /// Used to register core message handlers
 pub struct Handlers {}
 
 impl Handlers {
+    #[cfg(feature = "guest")]
     pub fn register_health_request(
         f: fn(HealthCheckRequest) -> HandlerResult<HealthCheckResponse>,
     ) {
@@ -22,11 +28,13 @@ impl Handlers {
     }
 }
 
+#[cfg(feature = "guest")]
 lazy_static! {
     static ref HEALTH_REQUEST: RwLock<Option<fn(HealthCheckRequest) -> HandlerResult<HealthCheckResponse>>> =
         RwLock::new(None);
 }
 
+#[cfg(feature = "guest")]
 fn health_request_wrapper(input_payload: &[u8]) -> CallResult {
     let input = deserialize::<HealthCheckRequest>(input_payload)?;
     let lock = HEALTH_REQUEST.read().unwrap().unwrap();

--- a/rust/keyvalue/Cargo.toml
+++ b/rust/keyvalue/Cargo.toml
@@ -10,10 +10,11 @@ readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+guest = ["wapc-guest"]
 
 [dependencies]
-wapc-guest = "0.4.0"
+wapc-guest = { version = "0.4.0", optional = true }
 serde = { version = "1.0.119" , features = ["derive"] }
 serde_json = "1.0.61"
 serde_bytes = "0.11.5"

--- a/rust/keyvalue/src/generated.rs
+++ b/rust/keyvalue/src/generated.rs
@@ -3,14 +3,18 @@ use rmps::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
+#[cfg(feature = "guest")]
 extern crate wapc_guest as guest;
+#[cfg(feature = "guest")]
 use guest::prelude::*;
 
 /// The abstraction of the key-value host capability
+#[cfg(feature = "guest")]
 pub struct Host {
     binding: String,
 }
 
+#[cfg(feature = "guest")]
 impl Default for Host {
     fn default() -> Self {
         Host {
@@ -20,6 +24,7 @@ impl Default for Host {
 }
 
 /// Creates a named host binding for the key-value store capability
+#[cfg(feature = "guest")]
 pub fn host(binding: &str) -> Host {
     Host {
         binding: binding.to_string(),
@@ -27,10 +32,12 @@ pub fn host(binding: &str) -> Host {
 }
 
 /// Creates the default host binding for the key-value store capability
+#[cfg(feature = "guest")]
 pub fn default() -> Host {
     Host::default()
 }
 
+#[cfg(feature = "guest")]
 impl Host {
     /// Retrieves a value stored in a given key
     pub fn get(&self, key: String) -> HandlerResult<GetResponse> {


### PR DESCRIPTION
Related to #22 

This enables the "guest" feature flag for the `actor-core` and `keyvalue` Rust interfaces. These are both needed by the `nats-kvcache` provider, and `keyvalue` is required by the `wasmcloud-host` crate. As denoted in the issue, the presence of this feature flag prevents `wapc-guest` from unnecessarily being included as a dependency and causing errors while building capability providers.

Marking as `do not merge` for now as I have not successfully tested the code, but I had to get it off my windows machine somehow