### PR TITLE
Initial commit of event stream interface

### DIFF
--- a/rust/eventstreams/Cargo.toml
+++ b/rust/eventstreams/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "actor-eventstreams"
+version = "0.1.0"
+authors = ["wasmCloud Team"]
+edition = "2018"
+description = "Interface to the event streams contract for use by wasmCloud Actors"
+license = "Apache-2.0"
+documentation = "https://docs.rs/actor-eventstreams"
+readme = "README.md"
+keywords = ["wasm", "wasmcloud", "actor", "events"]
+categories = ["wasm", "api-bindings"]
+
+[features]
+guest = ["wapc-guest", "lazy_static"]
+
+[dependencies]
+wapc-guest = { version = "0.4.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+
+serde = { version = "1.0.119" , features = ["derive"] }
+serde_json = "1.0.61"
+serde_bytes = "0.11.5"
+rmp-serde = "0.15.1"
+log = { version="0.4.13", features =["std","serde"]}
+

--- a/rust/eventstreams/Makefile
+++ b/rust/eventstreams/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all deps codegen build clean doc test
+
+all: deps codegen build
+
+deps:
+
+codegen:
+	wapc generate codegen.yaml
+
+build:
+	cargo build 	
+
+# Rust builds accrue disk space over time (specifically the target directory),
+# so running `make clean` should be done periodically.
+clean:
+	cargo clean
+	rm -Rf build
+
+doc:
+
+test: build
+	cargo test

--- a/rust/eventstreams/codegen.yaml
+++ b/rust/eventstreams/codegen.yaml
@@ -1,0 +1,5 @@
+schema: ../../schemas/eventstreams.widl
+generates:
+  src/generated.rs:
+    package: widl-codegen/language/rust
+    visitorClass: ModuleVisitor  

--- a/rust/eventstreams/src/generated.rs
+++ b/rust/eventstreams/src/generated.rs
@@ -1,0 +1,188 @@
+extern crate rmp_serde as rmps;
+use rmps::{Deserializer, Serializer};
+use serde::{Deserialize, Serialize};
+use std::io::Cursor;
+
+#[cfg(feature = "guest")]
+extern crate wapc_guest as guest;
+#[cfg(feature = "guest")]
+use guest::prelude::*;
+
+#[cfg(feature = "guest")]
+use lazy_static::lazy_static;
+#[cfg(feature = "guest")]
+use std::sync::RwLock;
+
+#[cfg(feature = "guest")]
+pub struct Host {
+    binding: String,
+}
+
+#[cfg(feature = "guest")]
+impl Default for Host {
+    fn default() -> Self {
+        Host {
+            binding: "default".to_string(),
+        }
+    }
+}
+
+/// Creates a named host binding for the key-value store capability
+#[cfg(feature = "guest")]
+pub fn host(binding: &str) -> Host {
+    Host {
+        binding: binding.to_string(),
+    }
+}
+
+/// Creates the default host binding for the key-value store capability
+#[cfg(feature = "guest")]
+pub fn default() -> Host {
+    Host::default()
+}
+
+#[cfg(feature = "guest")]
+impl Host {
+    pub fn write_event(
+        &self,
+        stream_id: String,
+        values: std::collections::HashMap<String, String>,
+    ) -> HandlerResult<String> {
+        let input_args = WriteEventArgs {
+            stream_id: stream_id,
+            values: values,
+        };
+        host_call(
+            &self.binding,
+            "wasmcloud:eventstreams",
+            "WriteEvent",
+            &serialize(input_args)?,
+        )
+        .map(|vec| {
+            let resp = deserialize::<String>(vec.as_ref()).unwrap();
+            resp
+        })
+        .map_err(|e| e.into())
+    }
+
+    pub fn query_stream(&self, query: StreamQuery) -> HandlerResult<Vec<Event>> {
+        host_call(
+            &self.binding,
+            "wasmcloud:eventstreams",
+            "QueryStream",
+            &serialize(query)?,
+        )
+        .map(|vec| {
+            let resp = deserialize::<Vec<Event>>(vec.as_ref()).unwrap();
+            resp
+        })
+        .map_err(|e| e.into())
+    }
+}
+
+#[cfg(feature = "guest")]
+pub struct Handlers {}
+
+#[cfg(feature = "guest")]
+impl Handlers {
+    pub fn register_deliver_event(f: fn(Event) -> HandlerResult<bool>) {
+        *DELIVER_EVENT.write().unwrap() = Some(f);
+        register_function(&"DeliverEvent", deliver_event_wrapper);
+    }
+}
+
+#[cfg(feature = "guest")]
+lazy_static! {
+    static ref DELIVER_EVENT: RwLock<Option<fn(Event) -> HandlerResult<bool>>> = RwLock::new(None);
+    static ref WRITE_EVENT: RwLock<Option<fn(String, std::collections::HashMap<String, String>) -> HandlerResult<String>>> =
+        RwLock::new(None);
+    static ref QUERY_STREAM: RwLock<Option<fn(StreamQuery) -> HandlerResult<Vec<Event>>>> =
+        RwLock::new(None);
+}
+
+#[cfg(feature = "guest")]
+fn deliver_event_wrapper(input_payload: &[u8]) -> CallResult {
+    let input = deserialize::<Event>(input_payload)?;
+    let lock = DELIVER_EVENT.read().unwrap().unwrap();
+    let result = lock(input)?;
+    Ok(serialize(result)?)
+}
+
+#[cfg(feature = "guest")]
+fn write_event_wrapper(input_payload: &[u8]) -> CallResult {
+    let input = deserialize::<WriteEventArgs>(input_payload)?;
+    let lock = WRITE_EVENT.read().unwrap().unwrap();
+    let result = lock(input.stream_id, input.values)?;
+    Ok(serialize(result)?)
+}
+
+#[cfg(feature = "guest")]
+fn query_stream_wrapper(input_payload: &[u8]) -> CallResult {
+    let input = deserialize::<StreamQuery>(input_payload)?;
+    let lock = QUERY_STREAM.read().unwrap().unwrap();
+    let result = lock(input)?;
+    Ok(serialize(result)?)
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+pub struct WriteEventArgs {
+    #[serde(rename = "stream_id")]
+    pub stream_id: String,
+    #[serde(rename = "values")]
+    pub values: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+pub struct Event {
+    #[serde(rename = "eventId")]
+    pub event_id: String,
+    #[serde(rename = "streamId")]
+    pub stream_id: String,
+    #[serde(rename = "values")]
+    pub values: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+pub struct StreamQuery {
+    #[serde(rename = "streamId")]
+    pub stream_id: String,
+    #[serde(rename = "range")]
+    pub range: Option<TimeRange>,
+    #[serde(rename = "count")]
+    pub count: u64,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+pub struct TimeRange {
+    #[serde(rename = "minTime")]
+    pub min_time: u64,
+    #[serde(rename = "maxTime")]
+    pub max_time: u64,
+}
+
+/// The standard function for serializing codec structs into a format that can be
+/// used for message exchange between actor and host. Use of any other function to
+/// serialize could result in breaking incompatibilities.
+pub fn serialize<T>(
+    item: T,
+) -> ::std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
+where
+    T: Serialize,
+{
+    let mut buf = Vec::new();
+    item.serialize(&mut Serializer::new(&mut buf).with_struct_map())?;
+    Ok(buf)
+}
+
+/// The standard function for de-serializing codec structs from a format suitable
+/// for message exchange between actor and host. Use of any other function to
+/// deserialize could result in breaking incompatibilities.
+pub fn deserialize<'de, T: Deserialize<'de>>(
+    buf: &[u8],
+) -> ::std::result::Result<T, Box<dyn std::error::Error + Send + Sync>> {
+    let mut de = Deserializer::new(Cursor::new(buf));
+    match Deserialize::deserialize(&mut de) {
+        Ok(t) => Ok(t),
+        Err(e) => Err(format!("Failed to de-serialize: {}", e).into()),
+    }
+}

--- a/rust/eventstreams/src/lib.rs
+++ b/rust/eventstreams/src/lib.rs
@@ -1,0 +1,38 @@
+//! # Event Streams wasmCloud Actor Interface
+//!
+//! This crate provides an abstraction over the `wasmcloud:eventstreams` contract. This allows
+//! actors to write immutable events to a stream, receive events from a stream,
+//! and query events from a stream.
+//!
+//! # Example:
+//! ```
+//! extern crate actor_eventstreams as streams;
+//! // extern crate actor_core as actorcore;
+//! use wapc_guest::HandlerResult;
+//! use streams::StreamQuery;
+//! use std::collections::HashMap;
+//!
+//! #[no_mangle]
+//! pub fn wapc_init() {
+//!     streams::Handlers::register_deliver_event(deliver_event);
+//!//     actorcore::Handlers::register_health_request(health);
+//! }
+//!
+//! fn deliver_event(event: streams::Event) -> HandlerResult<bool> {
+//!    // process event, query streams, or send new events...
+//!    let _evts_so_far = streams::default()
+//!       .query_stream(StreamQuery{
+//!           stream_id: event.stream_id.to_string(),
+//!           range: None,
+//!           count: 0                   
+//!    });
+//!    let _eid = streams::default().write_event("hello_streams".to_string(),
+//!          HashMap::new());
+//!    Ok(true)
+//! }
+//! ```
+
+#[allow(dead_code)]
+mod generated;
+
+pub use generated::*;

--- a/schemas/eventstreams.widl
+++ b/schemas/eventstreams.widl
@@ -1,0 +1,24 @@
+namespace "wasmcloud:eventstreams"
+
+interface {    
+    DeliverEvent{event: Event}: bool
+    WriteEvent(stream_id: string, values: {string: string}): string
+    QueryStream{query: StreamQuery}: [Event]
+}
+
+type Event {
+    eventId: string
+    streamId: string
+    values: {string: string}
+}
+
+type StreamQuery {
+    streamId: string
+    range: TimeRange?
+    count: u64
+}
+
+type TimeRange {
+    minTime: u64
+    maxTime: u64
+}


### PR DESCRIPTION
**NOTE** for future CI (@billyoung ) - all these new actor interfaces will need to be tested with the guest feature enabled (`cargo test --features "guest"`) because I/we are putting example doctests in, illustrating how the interface is used by a guest module. The tests won't compile without the feature flag enabled.