### PR TITLE
Updated http-server actor-interface contract ID and guest feature flag

### DIFF
--- a/rust/http-server/Cargo.toml
+++ b/rust/http-server/Cargo.toml
@@ -10,15 +10,18 @@ readme = "README.md"
 keywords = ["webassembly", "wasm", "wascc", "actor"]
 categories = ["wasm", "api-bindings"]
 
+[features]
+guest = ["wapc-guest", "lazy_static"]
+
 [dependencies]
-wapc-guest = "0.4.0"
+wapc-guest = { version = "0.4.0", optional = true}
+lazy_static = { version = "1.4.0", optional = true}
 serde = { version = "1.0.119" , features = ["derive"] }
 serde_json = "1.0.61"
 serde_derive = "1.0.119"
 serde_bytes = "0.11.5"
 rmp-serde = "0.15.1"
 log = { version="0.4.13", features =["std","serde"]}
-lazy_static = "1.4.0"
 
 [profile.release]
 # Optimize for small code size

--- a/rust/http-server/README.md
+++ b/rust/http-server/README.md
@@ -1,7 +1,7 @@
 # HTTP Server Actor Interface
 
 This crate provides waSCC actors with an interface to the HTTP Server capability provider. Actors using this
-interface must have the claim `wascc:http_server` in order to have permission to handle requests, and they
+interface must have the claim `wasmcloud:httpserver` in order to have permission to handle requests, and they
 must have an active, configured binding to an HTTP Server capability provider.
 
 The HTTP Server provider is one-way, and only delivers messages to actors. Actors cannot make host calls

--- a/rust/http-server/src/generated.rs
+++ b/rust/http-server/src/generated.rs
@@ -4,18 +4,24 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
 extern crate log;
+#[cfg(feature = "guest")]
 extern crate wapc_guest as guest;
+#[cfg(feature = "guest")]
 use guest::prelude::*;
 
+#[cfg(feature = "guest")]
 use lazy_static::lazy_static;
+#[cfg(feature = "guest")]
 use std::sync::RwLock;
 
 /// Used for making calls from the actor to the host. There are no supported
 /// host calls for this capability provider
+#[cfg(feature = "guest")]
 pub struct Host {
     binding: String,
 }
 
+#[cfg(feature = "guest")]
 impl Default for Host {
     fn default() -> Self {
         Host {
@@ -25,6 +31,7 @@ impl Default for Host {
 }
 
 /// Requests a host abstraction for a given binding name
+#[cfg(feature = "guest")]
 pub fn host(binding: &str) -> Host {
     Host {
         binding: binding.to_string(),
@@ -32,15 +39,17 @@ pub fn host(binding: &str) -> Host {
 }
 
 /// Requests the default host abstraction
+#[cfg(feature = "guest")]
 pub fn default() -> Host {
     Host::default()
 }
 
+#[cfg(feature = "guest")]
 impl Host {
     pub fn handle_request(&self, request: Request) -> HandlerResult<Response> {
         host_call(
             &self.binding,
-            "wascc:http_server",
+            "wasmcloud:httpserver",
             "HandleRequest",
             &serialize(request)?,
         )
@@ -53,8 +62,10 @@ impl Host {
 }
 
 /// Used to register message handlers in the actor
+#[cfg(feature = "guest")]
 pub struct Handlers {}
 
+#[cfg(feature = "guest")]
 impl Handlers {
     /// Registers a request handler for the [Request](struct.Request.html) type
     pub fn register_handle_request(f: fn(Request) -> HandlerResult<Response>) {
@@ -63,11 +74,13 @@ impl Handlers {
     }
 }
 
+#[cfg(feature = "guest")]
 lazy_static! {
     static ref HANDLE_REQUEST: RwLock<Option<fn(Request) -> HandlerResult<Response>>> =
         RwLock::new(None);
 }
 
+#[cfg(feature = "guest")]
 fn handle_request_wrapper(input_payload: &[u8]) -> CallResult {
     let input = deserialize::<Request>(input_payload)?;
     let lock = HANDLE_REQUEST.read().unwrap().unwrap();

--- a/rust/http-server/src/lib.rs
+++ b/rust/http-server/src/lib.rs
@@ -2,7 +2,7 @@
 //! # HTTP Server wasmCloud Actor Interface
 //!
 //! This crate provides wasmCloud actors with an interface to the HTTP Server capability provider. Actors using this
-//! interface must have the claim `wascc:http_server` in order to have permission to handle requests, and they
+//! interface must have the claim `wasmcloud:httpserver` in order to have permission to handle requests, and they
 //! must have an active, configured binding to an HTTP Server capability provider.
 //!
 //! The HTTP Server provider is one-way, and only delivers messages to actors. Actors cannot make host calls
@@ -26,12 +26,12 @@
 //!
 
 pub mod generated;
-
-extern crate wapc_guest as guest;
 use serde::Serialize;
 use std::collections::HashMap;
 
-pub use generated::{deserialize, serialize, Handlers, Request, Response};
+#[cfg(feature = "guest")]
+pub use generated::Handlers;
+pub use generated::{deserialize, serialize, Request, Response};
 
 impl Response {
     /// Creates a response with a given status code and serializes the given payload as JSON
@@ -86,7 +86,9 @@ impl Response {
 }
 
 #[cfg(test)]
+#[cfg(feature = "guest")]
 mod test {
+    extern crate wapc_guest;
     use crate::{Handlers, Request, Response};
     use wapc_guest::HandlerResult;
     #[test]

--- a/schemas/http.widl
+++ b/schemas/http.widl
@@ -1,4 +1,4 @@
-namespace "wascc:http_server"
+namespace "wasmcloud:httpserver"
 
 interface {
   HandleRequest{request: Request}: Response


### PR DESCRIPTION
Related to #22 

This PR updates the http-server actor-interface to use the new contract ID, `wasmcloud:httpserver`, and includes the guest feature flag for capability provider compatibility.