### PR TITLE
Included body field in doctest

### DIFF
--- a/http-client/rust/src/lib.rs
+++ b/http-client/rust/src/lib.rs
@@ -31,7 +31,7 @@
 //!     // Form client request from server request
 //!     if msg.method == "GET".to_string() {
 //!         // Replace `request` with `httpclient::default().request`
-//!         let res = request(msg.method, API_URL.to_string(), msg.header)?;
+//!         let res = request(msg.method, API_URL.to_string(), msg.header, vec![])?;
 //!         // Form server response
 //!         Ok(httpserver::Response {
 //!             status_code: res.status_code,
@@ -44,7 +44,7 @@
 //!     }
 //! }
 //!
-//! # fn request(method: String, url: String, headers: std::collections::HashMap<String,String>) -> HandlerResult<httpclient::Response> {
+//! # fn request(method: String, url: String, headers: std::collections::HashMap<String,String>, body: Vec<u8>) -> HandlerResult<httpclient::Response> {
 //! #   Ok(httpclient::Response {
 //! #     status: "OK".to_string(),
 //! #     status_code: 200,


### PR DESCRIPTION
Previously the body field was missing from the httpclient doctest, since we were mocking out a method I didn't notice until I went to test the function. Now the doctest has parity with the current httpclient API