### PR TITLE
Renaming crates in their respective cargo.toml files

### DIFF
--- a/actor-core/rust/Cargo.toml
+++ b/actor-core/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-core"
+name = "wasmcloud-actor-core"
 description = "wasmCloud Core Actor Interface"
 version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-core"
+documentation = "https://docs.rs/wasmcloud-actor-core"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]

--- a/actor-core/rust/src/lib.rs
+++ b/actor-core/rust/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Example
 //! ```
-//! extern crate actor_core as actorcore; // Avoid using the module name `core`
+//! extern crate wasmcloud_actor_core as actorcore; 
 //! use wapc_guest::HandlerResult;
 //! use actorcore::{HealthCheckRequest, HealthCheckResponse, Handlers};
 //!

--- a/blobstore/rust/Cargo.toml
+++ b/blobstore/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-blobstore"
+name = "wasmcloud-actor-blobstore"
 version = "0.1.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the blobstore contract for use by wasmCloud Actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-blobstore"
+documentation = "https://docs.rs/wasmcloud-actor-blobstore"
 readme = "README.md"
 keywords = ["wasm", "wasmcloud", "actor", "events"]
 categories = ["wasm", "api-bindings"]
@@ -26,11 +26,11 @@ log = { version="0.4.14", features =["std","serde"]}
 
 [dev-dependencies]
 structopt = "0.3.21"
-serde_json = "1.0.61"
+serde_json = "1.0.62"
 base64 = "0.13.0"
-log = "0.4.11"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+log = "0.4.14"
+wasmcloud-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+wasmcloud-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
 
 [profile.release]
 # Optimize for small code size

--- a/blobstore/rust/src/lib.rs
+++ b/blobstore/rust/src/lib.rs
@@ -12,9 +12,9 @@
 //! ```rust
 //! extern crate wapc_guest as guest;
 //! use guest::prelude::*;
-//! use actor_blobstore as blobstore;
-//! use actor_http_server as http;
-//! use actor_core::serialize;
+//! use wasmcloud_actor_blobstore as blobstore;
+//! use wasmcloud_actor_http_server as http;
+//! use wasmcloud_actor_core::serialize;
 //! use blobstore::*;
 //! use serde_json::json;
 //! use log::{error, info};

--- a/eventstreams/rust/Cargo.toml
+++ b/eventstreams/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-eventstreams"
+name = "wasmcloud-actor-eventstreams"
 version = "0.1.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the event streams contract for use by wasmCloud Actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-eventstreams"
+documentation = "https://docs.rs/wasmcloud-actor-eventstreams"
 readme = "README.md"
 keywords = ["wasm", "wasmcloud", "actor", "events"]
 categories = ["wasm", "api-bindings"]
@@ -17,9 +17,9 @@ guest = ["wapc-guest", "lazy_static"]
 wapc-guest = { version = "0.4.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
-serde = { version = "1.0.119" , features = ["derive"] }
-serde_json = "1.0.61"
+serde = { version = "1.0.123" , features = ["derive"] }
+serde_json = "1.0.62"
 serde_bytes = "0.11.5"
-rmp-serde = "0.15.1"
-log = { version="0.4.13", features =["std","serde"]}
+rmp-serde = "0.15.4"
+log = { version="0.4.14", features =["std","serde"]}
 

--- a/eventstreams/rust/src/lib.rs
+++ b/eventstreams/rust/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Example:
 //! ```
-//! extern crate actor_eventstreams as streams;
+//! extern crate wasmcloud_actor_eventstreams as streams;
 //! // extern crate actor_core as actorcore;
 //! use wapc_guest::HandlerResult;
 //! use streams::StreamQuery;

--- a/extras/rust/Cargo.toml
+++ b/extras/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-extras"
+name = "wasmcloud-actor-extras"
 version = "0.1.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the extras contract for use by wasmCloud Actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-extras"
+documentation = "https://docs.rs/wasmcloud-actor-extras"
 readme = "README.md"
 keywords = ["wasm", "wasmcloud", "actor", "uuid", "random"]
 categories = ["wasm", "api-bindings"]
@@ -28,5 +28,5 @@ structopt = "0.3.21"
 serde_json = "1.0.61"
 base64 = "0.13.0"
 log = "0.4.11"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+wasmcloud-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+wasmcloud-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }

--- a/extras/rust/src/lib.rs
+++ b/extras/rust/src/lib.rs
@@ -16,15 +16,16 @@
 //! ```rust
 //! extern crate wapc_guest as guest;
 //! use guest::prelude::*;
-//! use actor_extras as extras;
-//! use actor_http_server as http;
+//! use wasmcloud_actor_core as core;
+//! use wasmcloud_actor_extras as extras;
+//! use wasmcloud_actor_http_server as http;
 //! use serde_json::json;
 //! use log::{error, info};
 //!
 //! #[no_mangle]
 //! pub fn wapc_init() {
 //!     http::Handlers::register_handle_request(generate_guid);
-//!     actor_core::Handlers::register_health_request(health);
+//!     core::Handlers::register_health_request(health);
 //! }
 //!
 //! /// Generate a Guid and return it in a JSON envelope
@@ -37,8 +38,8 @@
 //!
 //! }
 //!
-//! fn health(_: actor_core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
-//!   Ok(actor_core::HealthCheckResponse::healthy())   
+//! fn health(_: core::HealthCheckRequest) -> HandlerResult<core::HealthCheckResponse> {
+//!   Ok(core::HealthCheckResponse::healthy())   
 //! }
 //!
 //! # fn get_guid() -> HandlerResult<Option<String>> {

--- a/graphdb/rust/Cargo.toml
+++ b/graphdb/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-graphdb"
+name = "wasmcloud-actor-graphdb"
 version = "0.1.0"
 description = "GraphDB Actor Interface for wasmCloud Actors"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-graphdb"
+documentation = "https://docs.rs/wasmcloud-actor-graphdb"
 readme = "README.md"
 repository = "https://github.com/wasmCloud/actor-interfaces"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor", "graph", "graphdb"]
@@ -32,7 +32,7 @@ actor-core = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "
 structopt = "0.3.17"
 serde_json = "1.0.57"
 base64 = "0.12.3"
-actor-http-server = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main", features = ["guest"]}
+wasmcloud-actor-http-server = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main", features = ["guest"]}
 
 [profile.release]
 # Optimize for small code size

--- a/http-client/rust/Cargo.toml
+++ b/http-client/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-http-client"
+name = "wasmcloud-actor-http-client"
 version = "0.1.0"
 description = "HTTP Client Actor Interface for wasmCloud Actors"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-http-client"
+documentation = "https://docs.rs/wasmcloud-actor-http-client"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
@@ -15,14 +15,14 @@ guest = ["wapc-guest", "lazy_static"]
 
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }
-serde = { version = "1.0.115" , features = ["derive"] }
+serde = { version = "1.0.123" , features = ["derive"] }
 serde_bytes = "0.11.5"
-rmp-serde = "0.14.4"
+rmp-serde = "0.15.4"
 lazy_static = { version = "1.4.0", optional = true}
 
 [dev-dependencies]
-structopt = "0.3.17"
-serde_json = "1.0.57"
-base64 = "0.12.3"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
+structopt = "0.3.21"
+serde_json = "1.0.62"
+base64 = "0.13.0"
+wasmcloud-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
+wasmcloud-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}

--- a/http-client/rust/src/lib.rs
+++ b/http-client/rust/src/lib.rs
@@ -10,9 +10,9 @@
 //! # Example:
 //! ```
 //! use wapc_guest::HandlerResult;
-//! extern crate actor_http_server as httpserver;
-//! extern crate actor_http_client as httpclient;
-//! extern crate actor_core as core;
+//! extern crate wasmcloud_actor_http_server as httpserver;
+//! extern crate wasmcloud_actor_http_client as httpclient;
+//! extern crate wasmcloud_actor_core as core;
 //!
 //! const API_URL: &str = "https://wasmcloudapi.cloud.io/proxy";
 //!

--- a/http-server/rust/Cargo.toml
+++ b/http-server/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-http-server"
+name = "wasmcloud-actor-http-server"
 version = "0.1.0"
-description = "HTTP Server Actor Interface for waSCC Actors"
-authors = ["waSCC Team"]
+description = "HTTP Server Actor Interface for wasmCloud Actors"
+authors = ["wasmcloud Team"]
 edition = "2018"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-http-server"
+documentation = "https://docs.rs/wasmcloud-actor-http-server"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wascc", "actor"]
 categories = ["wasm", "api-bindings"]
@@ -16,12 +16,12 @@ guest = ["wapc-guest", "lazy_static"]
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true}
 lazy_static = { version = "1.4.0", optional = true}
-serde = { version = "1.0.119" , features = ["derive"] }
-serde_json = "1.0.61"
-serde_derive = "1.0.119"
+serde = { version = "1.0.123" , features = ["derive"] }
+serde_json = "1.0.62"
+serde_derive = "1.0.123"
 serde_bytes = "0.11.5"
-rmp-serde = "0.15.1"
-log = { version="0.4.13", features =["std","serde"]}
+rmp-serde = "0.15.4"
+log = { version="0.4.14", features =["std","serde"]}
 
 [profile.release]
 # Optimize for small code size

--- a/http-server/rust/src/lib.rs
+++ b/http-server/rust/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! # Example:
 //! ```
-//! extern crate actor_http_server as http;
+//! extern crate wasmcloud_actor_http_server as http;
 //! use wapc_guest::HandlerResult;
 //! use http::{Request, Response, Handlers};
 //!

--- a/keyvalue/rust/Cargo.toml
+++ b/keyvalue/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-keyvalue"
+name = "wasmcloud-actor-keyvalue"
 version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the key-value contract for use by wasmCloud Actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-keyvalue"
+documentation = "https://docs.rs/wasmcloud-actor-keyvalue"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
@@ -15,9 +15,9 @@ guest = ["wapc-guest"]
 
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }
-serde = { version = "1.0.119" , features = ["derive"] }
-serde_json = "1.0.61"
+serde = { version = "1.0.123" , features = ["derive"] }
+serde_json = "1.0.62"
 serde_bytes = "0.11.5"
-rmp-serde = "0.15.1"
-log = { version="0.4.13", features =["std","serde"]}
+rmp-serde = "0.15.4"
+log = { version="0.4.14", features =["std","serde"]}
 lazy_static = "1.4.0"

--- a/keyvalue/rust/src/lib.rs
+++ b/keyvalue/rust/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example:
 //! ```
-//! extern crate actor_keyvalue as kv;
+//! extern crate wasmcloud_actor_keyvalue as kv;
 //! use wapc_guest::HandlerResult;
 //!
 //! fn add() -> HandlerResult<()> {

--- a/logging/rust/Cargo.toml
+++ b/logging/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-logging"
+name = "wasmcloud-actor-logging"
 version = "0.1.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the logging contract for use by wasmCloud Actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-logging"
+documentation = "https://docs.rs/wasmcloud-actor-logging"
 readme = "README.md"
 keywords = ["wasm", "wasmcloud", "actor", "events"]
 categories = ["wasm", "api-bindings"]
@@ -16,13 +16,13 @@ guest = ["wapc-guest", "lazy_static"]
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-serde = { version = "1.0.115" , features = ["derive"] }
+serde = { version = "1.0.123" , features = ["derive"] }
 serde_bytes = "0.11.5"
-rmp-serde = "0.14.4"
-log = { version="0.4.11", features =["std","serde"]}
+rmp-serde = "0.15.4"
+log = { version="0.4.14", features =["std","serde"]}
 
 [dev-dependencies]
-structopt = "0.3.17"
-serde_json = "1.0.57"
-base64 = "0.12.3"
-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
+structopt = "0.3.21"
+serde_json = "1.0.62"
+base64 = "0.13.0"
+wasmcloud-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}

--- a/logging/rust/src/lib.rs
+++ b/logging/rust/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! Example:
 //! ```rust
-//! extern crate actor_http_server as http;
-//! extern crate actor_logging as logging;
+//! extern crate wasmcloud_actor_http_server as http;
+//! extern crate wasmcloud_actor_logging as logging;
 //! use wapc_guest::HandlerResult;
 //! use http::{Request, Response, Handlers};
 //! use log::{info, warn, error, trace, debug};

--- a/messaging/rust/Cargo.toml
+++ b/messaging/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-messaging"
+name = "wasmcloud-actor-messaging"
 version = "0.1.0"
 description = "Messaging wasmCloud Actor Interface"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-messaging"
+documentation = "https://docs.rs/wasmcloud-actor-messaging"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
@@ -16,12 +16,12 @@ guest = ["wapc-guest", "lazy_static"]
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true}
 lazy_static = { version = "1.4.0", optional = true}
-serde = { version = "1.0.115" , features = ["derive"] }
+serde = { version = "1.0.123" , features = ["derive"] }
 serde_bytes = "0.11.5"
-rmp-serde = "0.14.4"
+rmp-serde = "0.15.4"
 
 [dev-dependencies]
-structopt = "0.3.17"
-serde_json = "1.0.57"
-base64 = "0.12.3"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}
+structopt = "0.3.21"
+serde_json = "1.0.62"
+base64 = "0.13.0"
+wasmcloud-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"]}

--- a/messaging/rust/src/lib.rs
+++ b/messaging/rust/src/lib.rs
@@ -7,13 +7,14 @@
 //!
 //! # Example:
 //! ```rust
-//! extern crate actor_messaging as messaging;
+//! extern crate wasmcloud_actor_messaging as messaging;
+//! extern crate wasmcloud_actor_core as core;
 //! extern crate wapc_guest as guest;
 //! use guest::prelude::*;
 //!
 //! #[no_mangle]
 //! pub fn wapc_init() {
-//!     actor_core::Handlers::register_health_request(health);
+//!     core::Handlers::register_health_request(health);
 //!     messaging::Handlers::register_handle_message(handle_message);
 //! }
 //!
@@ -25,8 +26,8 @@
 //!     Ok(())
 //! }
 //!
-//! fn health(_: actor_core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
-//!   Ok(actor_core::HealthCheckResponse::healthy())   
+//! fn health(_: core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
+//!   Ok(core::HealthCheckResponse::healthy())   
 //! }
 //! ```
 

--- a/telnet/rust/Cargo.toml
+++ b/telnet/rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "actor-telnet"
+name = "wasmcloud-actor-telnet"
 version = "0.1.0"
 edition = "2018"
 description = "Actor interface for the wasmCloud telnet capability provider"
 authors = ["wasmCloud Team"]
 license = "Apache-2.0"
-documentation = "https://docs.rs/actor-telnet"
+documentation = "https://docs.rs/wasmcloud-actor-telnet"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "telnet", "actor"]
 categories = ["wasm", "api-bindings"]
@@ -15,9 +15,9 @@ guest = ["wapc-guest"]
 
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }
-rmp-serde = "0.15.1"
-serde = { version = "1.0.119" , features = ["derive"] }
-log = { version="0.4.13", features =["std","serde"]}
+rmp-serde = "0.15.4"
+serde = { version = "1.0.123" , features = ["derive"] }
+log = { version="0.4.14", features =["std","serde"]}
 lazy_static = "1.4.0"
 
 [profile.release]

--- a/telnet/rust/src/lib.rs
+++ b/telnet/rust/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! # Example:
 //! ```
-//! extern crate actor_telnet as telnet;
-//! // extern crate actor_core as actorcore;
+//! extern crate wasmcloud_actor_telnet as telnet;
+//! // extern crate wasmcloud_actor_core as actorcore;
 //! use wapc_guest::HandlerResult;
 //!
 //! #[no_mangle]


### PR DESCRIPTION
This is an awkward chicken and the egg because the doctests that normally validate whether these APIs work are looking for crates sitting in github that, until we merge the PR, won't exist.