### PR TITLE
GraphDB moved actor-core to dev-dependencies

### DIFF
--- a/graphdb/rust/Cargo.toml
+++ b/graphdb/rust/Cargo.toml
@@ -26,13 +26,13 @@ serde_bytes = "0.11.5"
 rmp-serde = "0.14.4"
 log = { version="0.4.11", features =["std","serde"]}
 lazy_static = "1.4.0"
-wasmcloud-actor-core = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main", optional = true}
 
 [dev-dependencies]
 structopt = "0.3.17"
 serde_json = "1.0.57"
 base64 = "0.12.3"
-wasmcloud-actor-http-server = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main", features = ["guest"]}
+wasmcloud-actor-core = { version = "0.2.0", features = ["guest"]}
+wasmcloud-actor-http-server = { version = "0.1.0", features = ["guest"]}
 
 [profile.release]
 # Optimize for small code size


### PR DESCRIPTION
Looks like the release for `wasmcloud-actor-graphdb` ended up because of a git dependency, fixed that up and moved it to the dev dependencies section as it's only needed for tests.