### PR TITLE
Removed actor-core feature flag

### DIFF
--- a/graphdb/rust/Cargo.toml
+++ b/graphdb/rust/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["wasm", "api-bindings"]
 maintenance = { status = "actively-developed" }
 
 [features]
-guest = ["wapc-guest", "wasmcloud-actor-core/guest"]
+guest = ["wapc-guest"]
 
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }


### PR DESCRIPTION
This flag is no longer needed as the actor-core guest dependency has been moved to a dev dependency, and is no longer optional as it's used for doctests.