### PR TITLE
Removing scalar return types from event stream contract

### DIFF
--- a/eventstreams/eventstreams.widl
+++ b/eventstreams/eventstreams.widl
@@ -1,15 +1,23 @@
 namespace "wasmcloud:eventstreams"
 
-interface {    
-    DeliverEvent{event: Event}: bool
-    WriteEvent(stream_id: string, values: {string: string}): string
-    QueryStream{query: StreamQuery}: [Event]
+interface {       
+    WriteEvent(streamId: string, values: {string: string}): EventAck
+    QueryStream{query: StreamQuery}: EventList
 }
 
 type Event {
     eventId: string
     streamId: string
     values: {string: string}
+}
+
+type EventAck {
+    eventId: string?
+    error: string?
+}
+
+type EventList {
+    events: [Event]
 }
 
 type StreamQuery {

--- a/eventstreams/rust/Cargo.toml
+++ b/eventstreams/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-actor-eventstreams"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the event streams contract for use by wasmCloud Actors"
@@ -11,11 +11,10 @@ keywords = ["wasm", "wasmcloud", "actor", "events"]
 categories = ["wasm", "api-bindings"]
 
 [features]
-guest = ["wapc-guest", "lazy_static"]
+guest = ["wapc-guest"]
 
 [dependencies]
 wapc-guest = { version = "0.4.0", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 
 serde = { version = "1.0.123" , features = ["derive"] }
 serde_json = "1.0.62"
@@ -23,3 +22,6 @@ serde_bytes = "0.11.5"
 rmp-serde = "0.15.4"
 log = { version="0.4.14", features =["std","serde"]}
 
+[dev-dependencies]
+wasmcloud-actor-http-server = {version = "0.1.1", features = ["guest"] }
+wasmcloud-actor-core = { version = "0.2.2", features = ["guest"] }

--- a/eventstreams/rust/README.md
+++ b/eventstreams/rust/README.md
@@ -1,37 +1,41 @@
-[![crates.io](https://img.shields.io/crates/v/wasmcloud-actor-eventstreams.svg)](https://crates.io/crates/wasmcloud-actor-eventstreams)&nbsp;
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-actor-eventstreams.svg)](https://crates.io/crates/wasmcloud-actor-eventstreams)
 ![Rust](https://img.shields.io/github/workflow/status/wasmcloud/actor-interfaces/Event%20Streams)
-![license](https://img.shields.io/crates/l/wasmcloud-actor-eventstreams.svg)&nbsp;
+![license](https://img.shields.io/crates/l/wasmcloud-actor-eventstreams.svg)
 [![documentation](https://docs.rs/wasmcloud-actor-eventstreams/badge.svg)](https://docs.rs/wasmcloud-actor-eventstreams)
+
 # wasmCloud Event Streams Actor Interface
 
 This crate provides an abstraction over the `wasmcloud:eventstreams` contract. This allows
 actors to write immutable events to a stream, receive events from a stream,
 and query events from a stream.
 
-# Example:
+# Example
+
 ```rust
+#[macro_use]
+extern crate wasmcloud_actor_core as actor;
 extern crate wasmcloud_actor_eventstreams as streams;
+extern crate wasmcloud_actor_http_server as http;
+
 use wapc_guest::HandlerResult;
-use streams::StreamQuery;
+use streams::*;
 use std::collections::HashMap;
 
-#[no_mangle]
-pub fn wapc_init() {
-    streams::Handlers::register_deliver_event(deliver_event);
-    wasmcloud_actor)core::Handlers::register_health_request(health);
+#[actor::init]
+fn init() {
+   http::Handlers::register_handle_request(handle_request);
 }
 
-fn deliver_event(event: streams::Event) -> HandlerResult<bool> {
+fn handle_request(_req: http::Request) -> HandlerResult<http::Response> {
    // process event, query streams, or send new events...
    let _evts_so_far = streams::default()
       .query_stream(StreamQuery{
-          stream_id: event.stream_id.to_string(),
+          stream_id: "hello_stream".to_string(),
           range: None,
           count: 0                   
    });
-   let _eid = streams::default().write_event("hello_streams".to_string(),
-         HashMap::new());
-   Ok(true)
+   let ack = streams::default().write_event("hello_stream".to_string(),
+         HashMap::new())?;
+   Ok(http::Response::ok())
 }
 ```
-

--- a/eventstreams/rust/src/lib.rs
+++ b/eventstreams/rust/src/lib.rs
@@ -6,29 +6,31 @@
 //!
 //! # Example:
 //! ```
+//! extern crate wasmcloud_actor_core as actor;
+//! use actor::init;
 //! extern crate wasmcloud_actor_eventstreams as streams;
-//! // extern crate actor_core as actorcore;
+//! extern crate wasmcloud_actor_http_server as http;
+//!
 //! use wapc_guest::HandlerResult;
-//! use streams::StreamQuery;
+//! use streams::*;
 //! use std::collections::HashMap;
 //!
-//! #[no_mangle]
-//! pub fn wapc_init() {
-//!     streams::Handlers::register_deliver_event(deliver_event);
-//!//     actorcore::Handlers::register_health_request(health);
+//! #[actor::init]
+//! fn init() {
+//!   http::Handlers::register_handle_request(handle_request);
 //! }
 //!
-//! fn deliver_event(event: streams::Event) -> HandlerResult<bool> {
+//! fn handle_request(_req: http::Request) -> HandlerResult<http::Response> {
 //!    // process event, query streams, or send new events...
 //!    let _evts_so_far = streams::default()
 //!       .query_stream(StreamQuery{
-//!           stream_id: event.stream_id.to_string(),
+//!           stream_id: "hello_stream".to_string(),
 //!           range: None,
 //!           count: 0                   
 //!    });
-//!    let _eid = streams::default().write_event("hello_streams".to_string(),
-//!          HashMap::new());
-//!    Ok(true)
+//!    let ack = streams::default().write_event("hello_stream".to_string(),
+//!          HashMap::new())?;
+//!    Ok(http::Response::ok())
 //! }
 //! ```
 
@@ -36,3 +38,6 @@
 mod generated;
 
 pub use generated::*;
+
+pub const OP_WRITE_EVENT: &str = "WriteEvent";
+pub const OP_QUERY_STREAM: &str = "QueryStream";


### PR DESCRIPTION
Per discussion in slack, the current Rust generated code using message pack can't properly de-serialize things without field names, which includes all kinds of scalars like `string` or even collections of types like `[Event]`. So I've wrapped all the return types in a container struct and I've removed the unused "deliver event" operation.