### PR TITLE
Refactoring blob store interface contract

### DIFF
--- a/blobstore/blobstore.widl
+++ b/blobstore/blobstore.widl
@@ -1,15 +1,21 @@
 namespace "wasmcloud:blobstore"
 
 interface {        
-    CreateContainer(container: Container): Container
-    RemoveContainer(container: Container): void
-    RemoveObject(blob: Blob): void
-    ListObjects(container: Container): BlobList
-    UploadChunk(chunk: FileChunk): void
-    StartDownload(request: StreamRequest): void
-    StartUpload(blob: FileChunk): void
-    ReceiveChunk(chunk: FileChunk): void
-    GetObjectInfo(blob: Blob): Blob
+    CreateContainer(id: string): Container
+    RemoveContainer(id: string): BlobstoreResult
+    RemoveObject(id: string, container_id: string): BlobstoreResult
+    ListObjects(container_id: string): BlobList
+    UploadChunk{chunk: FileChunk}: void
+    StartDownload(blob_id: string, container_id: string, chunk_size: u64, context: string?): BlobstoreResult
+    StartUpload{blob: FileChunk}: BlobstoreResult    
+    GetObjectInfo(blob_id: string, container_id: string): Blob
+
+    ReceiveChunk{chunk: FileChunk}: void
+}
+
+type BlobstoreResult {
+    success: bool
+    error: string?
 }
 
 type FileChunk {

--- a/blobstore/rust/Cargo.toml
+++ b/blobstore/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-actor-blobstore"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the blobstore contract for use by wasmCloud Actors"
@@ -29,8 +29,8 @@ structopt = "0.3.21"
 serde_json = "1.0.62"
 base64 = "0.13.0"
 log = "0.4.14"
-wasmcloud-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
-wasmcloud-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main", features = ["guest"] }
+wasmcloud-actor-core = { version ="0.2.2", features = ["guest"] }
+wasmcloud-actor-http-server = { version = "0.1.1", features = ["guest"] }
 
 [profile.release]
 # Optimize for small code size

--- a/blobstore/rust/README.md
+++ b/blobstore/rust/README.md
@@ -1,7 +1,8 @@
-[![crates.io](https://img.shields.io/crates/v/wasmcloud-actor-blobstore.svg)](https://crates.io/crates/wasmcloud-actor-blobstore)&nbsp;
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-actor-blobstore.svg)](https://crates.io/crates/wasmcloud-actor-blobstore)
 ![Rust](https://img.shields.io/github/workflow/status/wasmcloud/actor-interfaces/Blobstore)
-![license](https://img.shields.io/crates/l/wasmcloud-actor-blobstore.svg)&nbsp;
+![license](https://img.shields.io/crates/l/wasmcloud-actor-blobstore.svg)
 [![documentation](https://docs.rs/wasmcloud-actor-blobstore/badge.svg)](https://docs.rs/wasmcloud-actor-blobstore)
+
 # wasmCloud Blob Store Actor Interface
 
 This crate provides wasmCloud actors with an interface to the blobstore capability provider.
@@ -11,50 +12,41 @@ permission to communicate with the store.
 This generic protocol can be used to support capability providers like local blob storage,
 Amazon S3, Azure blob storage, Google blob storage, and more.
 
-Example:
+## Example
+
 ```rust
 extern crate wapc_guest as guest;
 use guest::prelude::*;
 use wasmcloud_actor_blobstore as blobstore;
 use wasmcloud_actor_http_server as http;
-use wasmcloud_actor_core::serialize;
+use wasmcloud_actor_core as actor;
+use actor::{serialize, init};
 use blobstore::*;
 use serde_json::json;
 use log::{error, info};
 
-#[no_mangle]
-pub fn wapc_init() {
+#[actor::init]
+fn init() {
     http::Handlers::register_handle_request(download_poem);
-    blobstore::Handlers::register_receive_chunk(handle_chunk);
-    actor_core::Handlers::register_health_request(health);
+    blobstore::Handlers::register_receive_chunk(handle_chunk);   
 }
 
-/// Start the download of a blob (poem). Chunks will be streamed after download begins
-fn download_poem(req: http::Request) -> HandlerResult<http::Response> {
-    let stream_request = StreamRequest {
-        id: req.path,
-        container: Container::new("photos".to_string()),
-        chunk_size: 4096,
-        context: None
-    };
-    // replace `start_download` with `blobstore::default().start_download`
-    match start_download(stream_request) {
+fn download_poem(req: http::Request) -> HandlerResult<http::Response> {    
+    match blobstore::default().start_download(req.path, "poems".to_string(), 4096, None) {
         Ok(_) => Ok(http::Response::ok()),
         Err(_) => Err("Failed to initiate download of chunk".into())
     }
 }
 
-/// Handle the incoming chunk as a poem "verse" and log the result
-/// Note that these chunks can be received out of order, so the poem
-/// in this case might be displayed in a different order.
-fn handle_chunk(chunk: FileChunk) -> HandlerResult<()> {
-    let verse = String::from_utf8(chunk.chunk_bytes)?;
-    info!("Poem {} part {}:\n{}", chunk.id, chunk.sequence_no, verse);
-    Ok(())
-}
+ /// Handle the incoming chunk as a poem "verse" and log the result
+ /// Note that these chunks can be received out of order, so the poem
+ /// in this case might be displayed in a different order and could look
+ /// funny if the verse continues across a chunk boundary
+ fn handle_chunk(chunk: FileChunk) -> HandlerResult<()> {
+     let verse = String::from_utf8(chunk.chunk_bytes)?;
+     info!("Poem {} part {}:\n{}", chunk.id, chunk.sequence_no, verse);
+     Ok(())
+ }
 
-fn health(_: actor_core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
-  Ok(actor_core::HealthCheckResponse::healthy())   
-}
 
 ```

--- a/blobstore/rust/src/lib.rs
+++ b/blobstore/rust/src/lib.rs
@@ -8,35 +8,30 @@
 //! This generic protocol can be used to support capability providers like local blob storage,
 //! Amazon S3, Azure blob storage, Google blob storage, and more.
 //!
-//! //! Example:
+//! # Example:
+//!
 //! ```rust
 //! extern crate wapc_guest as guest;
 //! use guest::prelude::*;
 //! use wasmcloud_actor_blobstore as blobstore;
 //! use wasmcloud_actor_http_server as http;
 //! use wasmcloud_actor_core::serialize;
-//! use wasmcloud_actor_core as actor_core;
+//! use wasmcloud_actor_core as actor;
+//! use actor::init;
 //! use blobstore::*;
 //! use serde_json::json;
 //! use log::{error, info};
 //!
-//! #[no_mangle]
-//! pub fn wapc_init() {
+//! #[actor::init]
+//! fn init() {
 //!     http::Handlers::register_handle_request(download_poem);
 //!     blobstore::Handlers::register_receive_chunk(handle_chunk);
-//!     actor_core::Handlers::register_health_request(health);
 //! }
 //!
 //! /// Start the download of a blob (poem). Chunks will be streamed after download begins
 //! fn download_poem(req: http::Request) -> HandlerResult<http::Response> {
-//!     let stream_request = StreamRequest {
-//!         id: req.path,
-//!         container: Container::new("photos".to_string()),
-//!         chunk_size: 4096,
-//!         context: None
-//!     };
 //!     // replace `start_download` with `blobstore::default().start_download`
-//!     match start_download(stream_request) {
+//!     match start_download(req.path, "poems".to_string(), 4096, None) {
 //!         Ok(_) => Ok(http::Response::ok()),
 //!         Err(_) => Err("Failed to initiate download of chunk".into())
 //!     }
@@ -44,18 +39,16 @@
 //!
 //! /// Handle the incoming chunk as a poem "verse" and log the result
 //! /// Note that these chunks can be received out of order, so the poem
-//! /// in this case might be displayed in a different order.
+//! /// in this case might be displayed in a different order and could look
+//! /// funny if the verse continues across a chunk boundary
 //! fn handle_chunk(chunk: FileChunk) -> HandlerResult<()> {
 //!     let verse = String::from_utf8(chunk.chunk_bytes)?;
 //!     info!("Poem {} part {}:\n{}", chunk.id, chunk.sequence_no, verse);
 //!     Ok(())
 //! }
 //!
-//! fn health(_: actor_core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
-//!   Ok(actor_core::HealthCheckResponse::healthy())   
-//! }
 //!
-//! # fn start_download(req: StreamRequest) -> HandlerResult<()> {
+//! # fn start_download(id: String, container_id: String, chunk_size: u64, context: Option<String>) -> HandlerResult<()> {
 //! #   Ok(())
 //! # }
 //!


### PR DESCRIPTION
Closing #56 , the blob store interface had a number of outdated designs and a few areas of outright incompatibility. First step in fixing this is to upgrade this actor interface. Next, upgrade the s3 and file system providers to the new contract.