### PR TITLE
Closing #19 - http route matcher

### DIFF
--- a/http-server/rust/Cargo.toml
+++ b/http-server/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wasmcloud-actor-http-server"
-version = "0.1.1"
+version = "0.1.2"
 description = "HTTP Server Actor Interface for wasmCloud Actors"
 authors = ["wasmcloud Team"]
 edition = "2018"
 license = "Apache-2.0"
 documentation = "https://docs.rs/wasmcloud-actor-http-server"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "wascc", "actor"]
+keywords = ["webassembly", "wasm", "wasmcloud", "actor"]
 categories = ["wasm", "api-bindings"]
 
 [features]
@@ -23,7 +23,5 @@ serde_bytes = "0.11.5"
 rmp-serde = "0.15.4"
 log = { version="0.4.14", features =["std","serde"]}
 
-[profile.release]
-# Optimize for small code size
-opt-level = "s"
-lto = true
+[dev-dependencies]
+wasmcloud-actor-core= { version = "0.2.2", features = ["guest"]}

--- a/http-server/rust/src/lib.rs
+++ b/http-server/rust/src/lib.rs
@@ -14,7 +14,6 @@
 //! use wasmcloud_actor_core as actor;
 //! use wapc_guest::HandlerResult;
 //! use http::{Request, Response, Handlers, Method};
-//! use std::str::FromStr;
 //!
 //! #[actor::init]
 //! fn init() {
@@ -22,11 +21,10 @@
 //! }
 //!
 //! fn req_handler(req: http::Request) -> HandlerResult<http::Response> {
-//!     let method = Method::from_str(&req.method)?;
-//!     let path = req.path.to_string();
-//!     let segments = path.split('/').skip(1).collect::<Vec<_>>();
+//!     let method = req.method();
+//!     let segments = req.path_segments();
 //!
-//!     match (&method, &*segments)  {
+//!     match (method, &*segments)  {
 //!         (Method::Get, &["v0", "users", id]) => get_user(id),
 //!         (Method::Put, &["v1", "users", id]) => update_user(id, &req.body),
 //!         _ => Ok(http::Response::not_found())
@@ -51,6 +49,18 @@ pub use route::Method;
 #[cfg(feature = "guest")]
 pub use generated::Handlers;
 pub use generated::{deserialize, serialize, Request, Response};
+
+use std::str::FromStr;
+
+impl Request {
+    pub fn path_segments(&self) -> Vec<&str> {
+        self.path.split('/').skip(1).collect::<Vec<_>>()
+    }
+
+    pub fn method(&self) -> Method {
+        Method::from_str(&self.method).unwrap()
+    }
+}
 
 impl Response {
     /// Creates a response with a given status code and serializes the given payload as JSON

--- a/http-server/rust/src/route.rs
+++ b/http-server/rust/src/route.rs
@@ -1,0 +1,36 @@
+use std::{str::FromStr, string::ParseError};
+/// Valid values for an HTTP method
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Method {
+    Options,
+    Get,
+    Post,
+    Put,
+    Delete,
+    Head,
+    Trace,
+    Connect,
+    Patch,
+}
+
+impl FromStr for Method {
+    type Err = ParseError;
+
+    fn from_str(input: &str) -> std::result::Result<Self, <Self as FromStr>::Err> {
+        let input = input.to_ascii_uppercase();
+        let input = input.trim();
+
+        Ok(match input {
+            "OPTIONS" => Method::Options,
+            "GET" => Method::Get,
+            "POST" => Method::Post,
+            "PUT" => Method::Put,
+            "DELETE" => Method::Delete,
+            "TRACE" => Method::Trace,
+            "HEAD" => Method::Head,
+            "CONNECT" => Method::Connect,
+            "PATCH" => Method::Patch,
+            _ => Method::Get,
+        })
+    }
+}


### PR DESCRIPTION
Rather than build a big bloated route matcher and incurring a ton of unnecessary dependencies, I decided to just provide a convenience enum and some guidance on turning the path into a set of segments. the new example reflects a nice and easy, readable way of routing inbound requests.