### PR TITLE
Add a keys operation to keyvalue.widl

### DIFF
--- a/keyvalue/keyvalue.widl
+++ b/keyvalue/keyvalue.widl
@@ -60,6 +60,10 @@ role Store {
     Indicates if a key exists
     """
     KeyExists(key: string): GetResponse
+    """
+    Retrieve a list of keys
+    """
+    KeysQuery(query: string): KeysQueryResponse
 }
 
 """
@@ -117,5 +121,12 @@ type SetOperationResponse {
 Response type for set query operations
 """
 type SetQueryResponse {
+    values: [string]
+}
+
+"""
+Response type for keys query operations
+"""
+type KeysQueryResponse {
     values: [string]
 }


### PR DESCRIPTION
Redis supports a `keys` method that returns a list of keys that satisfy a given query.  For instance, `connection.keys("*")` will return all keys in the store.

It's possible we need to paginate this method in a similar fashion to the `Range` operation.  I'm happy to update the PR accordingly.  My current use case is small so retrieving all keys in the store is safe.