### PR TITLE
Returned blobstore to compliant contract

### DIFF
--- a/blobstore/assemblyscript/assembly/index.ts
+++ b/blobstore/assemblyscript/assembly/index.ts
@@ -87,7 +87,7 @@ export class Host {
     blob_id: string,
     container_id: string,
     chunk_size: u64,
-    context: string
+    context: string | null
   ): BlobstoreResult {
     const inputArgs = new StartDownloadArgs();
     inputArgs.blob_id = blob_id;

--- a/blobstore/assemblyscript/package-lock.json
+++ b/blobstore/assemblyscript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wasmcloud/actor-blobstore",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wasmcloud/actor-blobstore",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "dependencies": {
         "@wapc/as-guest": "^v0.2.1",

--- a/blobstore/assemblyscript/package.json
+++ b/blobstore/assemblyscript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wasmcloud/actor-blobstore",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Interface to the blobstore contract for use by wasmCloud Actors",
   "author": "wasmCloud team",
   "scripts": {

--- a/blobstore/blobstore.widl
+++ b/blobstore/blobstore.widl
@@ -5,39 +5,39 @@ role Store {
     Create a container in a blobstore.
     Returns the container created if successful
     """
-    CreateContainer(container: Container): Container
+    CreateContainer(id: string): Container
     """
     Remove a container from a blobstore
     """
-    RemoveContainer(container: Container): void
+    RemoveContainer(id: string): BlobstoreResult
     """
     Remove an object from a blobstore
     """
-    RemoveObject(blob: Blob): void
+    RemoveObject(id: string, container_id: string): BlobstoreResult
     """
     Returns a list of blobs that are present in the specified container
     """
-    ListObjects(container: Container): BlobList
+    ListObjects(container_id: string): BlobList
     """
     Upload a file chunk to a blobstore, which may only be part of a full file.
     This must be called AFTER the StartUpload operation. Chunks should be
     small, as memory over a few megabytes may exceed the wasm memory allocation.
     """
-    UploadChunk(chunk: FileChunk): void
+    UploadChunk(chunk: FileChunk): BlobstoreResult
     """
     Issue a request to start a download from a blobstore. Chunks will be sent
     to the function that's registered with the ReceiveChunk operation.
     """
-    StartDownload(request: StreamRequest): void
+    StartDownload(blob_id: string, container_id: string, chunk_size: u64, context: string?): BlobstoreResult
     """
     Begin the upload process with the first chunk of a full file. Subsequent
     chunks should be uploaded with the UploadChunk operation.
     """
-    StartUpload(chunk: FileChunk): void
+    StartUpload(chunk: FileChunk): BlobstoreResult
     """
     Retreives information about a blob
     """
-    GetObjectInfo(blob: Blob): Blob
+    GetObjectInfo(blob_id: string, container_id: string): Blob
 }
 
 role Actor {
@@ -96,16 +96,6 @@ type BlobList {
     blobs: [Blob]
 }
 
-"""
-Used to request a download from a blobstore
-"""
-type StreamRequest {
-    id: string
-    container: Container
-    chunkSize: u64
-    context: string?
-}
-
 type Transfer {
     blobId: string
     container: Container
@@ -113,4 +103,12 @@ type Transfer {
     totalSize: u64
     totalChunks: u64
     context: string?
+}
+
+"""
+Used to return success and error information for common blobstore operations
+"""
+type BlobstoreResult {
+    success: bool
+    error: string?
 }

--- a/blobstore/rust/Cargo.toml
+++ b/blobstore/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-actor-blobstore"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Interface to the blobstore contract for use by wasmCloud Actors"

--- a/blobstore/rust/README.md
+++ b/blobstore/rust/README.md
@@ -15,7 +15,7 @@ Amazon S3, Azure blob storage, Google blob storage, and more.
 ## Example
 
 ```rust
-extern crate wapc_guest as guest;
+use wapc_guest as guest;
 use guest::prelude::*;
 use wasmcloud_actor_blobstore as blobstore;
 use wasmcloud_actor_http_server as http;

--- a/blobstore/rust/src/generated.rs
+++ b/blobstore/rust/src/generated.rs
@@ -126,7 +126,7 @@ impl Host {
         blob_id: String,
         container_id: String,
         chunk_size: u64,
-        context: String,
+        context: Option<String>,
     ) -> HandlerResult<BlobstoreResult> {
         let input_args = StartDownloadArgs {
             blob_id,


### PR DESCRIPTION
A previous PR #40 mistakenly broke the API with some changes that came from a _previous_ version of the blobstore interface. This PR bumps a patch version to bring the API back to a compliant status.